### PR TITLE
Fix #13 - Proposal for processing multiple files and #include directives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,7 @@ script:
       -v $HOME/.sbt:/root/.sbt \
       -v $HOME/.ivy2:/root/.ivy2 \
       -t rgomes/scalanative:1.0-M1 /bin/bash -c \
-         " cd /root; \
-           rm -r -f ~/.ivy2/cache/com.lihaoyi/ ~/.ivy2/local/com.lihaoyi/; \
-           git clone https://github.com/lihaoyi/utest; \
-           pushd utest; \
-           sbt clean +publishLocal; \
-           popd; \
-           wget -O /tmp/utest_native0.3_2.11.jar https://www.dropbox.com/sh/bb3p4grafp0027a/AAB7-L1d6fkNmVPVVajua5vRa/utest_native0.3_2.11.jar; \
-           cd /root/scala-bindgen; \
+         " cd /root/scala-bindgen; \
            bin/scalafmt --test; \
            bin/clangfmt --test; \
            sbt clean bindgen/test tests/test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ script:
       -v $HOME/.ivy2:/root/.ivy2 \
       -t rgomes/scalanative:1.0-M1 /bin/bash -c \
          " cd /root; \
+           rm -r -f ~/.ivy2/cache/com.lihaoyi/ ~/.ivy2/local/com.lihaoyi/; \
            git clone https://github.com/lihaoyi/utest; \
            pushd utest; \
-           sbt clean publishLocal; \
+           sbt clean +publishLocal; \
            popd; \
            cd /root/scala-bindgen; \
            bin/scalafmt --test; \

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ script:
            pushd utest; \
            sbt clean +publishLocal; \
            popd; \
+           wget -O /tmp/utest_native0.3_2.11.jar https://www.dropbox.com/sh/bb3p4grafp0027a/AAB7-L1d6fkNmVPVVajua5vRa/utest_native0.3_2.11.jar; \
            cd /root/scala-bindgen; \
            bin/scalafmt --test; \
            bin/clangfmt --test; \
-           sbt clean tests/test"
+           sbt clean bindgen/test tests/test"
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,14 @@ script:
       -v $HOME/.sbt:/root/.sbt \
       -v $HOME/.ivy2:/root/.ivy2 \
       -t rgomes/scalanative:1.0-M1 /bin/bash -c \
-         " cd /root/scala-bindgen; \
-           bin/scalafmt --test
-           bin/clangfmt --test
+         " cd /root; \
+           git clone https://github.com/lihaoyi/utest; \
+           pushd utest; \
+           sbt clean publishLocal; \
+           popd; \
+           cd /root/scala-bindgen; \
+           bin/scalafmt --test; \
+           bin/clangfmt --test; \
            sbt clean tests/test"
 
 before_cache:

--- a/bindgen/src/test/scala/FileUtilsSpec.scala
+++ b/bindgen/src/test/scala/FileUtilsSpec.scala
@@ -1,0 +1,199 @@
+package bindgen
+
+import utest._
+
+object Test extends TestSuite {
+  val util = new Object with FileUtils
+  val tests = this {
+    "ability to determine output file name" - {
+
+      "when output goes to STDOUT"-{
+        "well formed chdir and default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "-"
+          val default  = "test.h"
+          val expected = "-"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir"-{
+          val chdir = null
+          val out   = "-"
+          val default  = "test.h"
+          val expected = "-"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "-"
+          val default  = null
+          val expected = "-"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir and default"-{
+          val chdir = null
+          val out   = "-"
+          val default  = null
+          val expected = "-"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+      }
+
+
+      "when output assumes defaults"-{
+        "well formed chdir and default, output is null"-{
+          val chdir = "target/bindgen/tests"
+          val out   = null // assuming defaults means that this can be either null or ""
+          val default  = "test.h"
+          val expected = "target/bindgen/tests/test.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "well formed chdir and default, output is empty"-{
+          val chdir = "target/bindgen/tests"
+          val out   = null // assuming defaults means that this can be either null or ""
+          val default  = "test.h"
+          val expected = "target/bindgen/tests/test.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir"-{
+          val chdir = null
+          val out   = null // assuming defaults means that this can be either null or ""
+          val default  = "test.h"
+          val expected = "./test.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = null // assuming defaults means that this can be either null or ""
+          val default  = null
+          intercept[IllegalArgumentException] {
+            util.resolve(chdir, out, default, ".h", ".scala")
+          }
+        }
+        "badly formed chdir and default"-{
+          val chdir = null
+          val out   = null // assuming defaults means that this can be either null or ""
+          val default  = null
+          intercept[IllegalArgumentException] {
+            util.resolve(chdir, out, default, ".h", ".scala")
+          }
+        }
+      }
+
+
+      "when output specifies a simple file name"-{
+        "well formed chdir and default, output is null"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "unified.scala"
+          val default  = "test.h"
+          val expected = "target/bindgen/tests/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir"-{
+          val chdir = null
+          val out   = "unified.scala"
+          val default  = "test.h"
+          val expected = "./unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "unified.scala"
+          val default  = null
+          val expected = "target/bindgen/tests/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir and default"-{
+          val chdir = null
+          val out   = "unified.scala"
+          val default  = null
+          val expected = "./unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+      }
+
+
+      "when output specifies a relative file name"-{
+        "well formed chdir and default, output is null"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "another/unified.scala"
+          val default  = "test.h"
+          val expected = "target/bindgen/tests/another/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir"-{
+          val chdir = null
+          val out   = "another/unified.scala"
+          val default  = "test.h"
+          val expected = "./another/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "another/unified.scala"
+          val default  = null
+          val expected = "target/bindgen/tests/another/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir and default"-{
+          val chdir = null
+          val out   = "another/unified.scala"
+          val default  = null
+          val expected = "./another/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+      }
+
+
+      "when output specifies an absolute file name"-{
+        "well formed chdir and default, output is null"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "/tmp/unified.scala"
+          val default  = "test.h"
+          val expected = "/tmp/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir"-{
+          val chdir = null
+          val out   = "/tmp/unified.scala"
+          val default  = "test.h"
+          val expected = "/tmp/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed default"-{
+          val chdir = "target/bindgen/tests"
+          val out   = "/tmp/unified.scala"
+          val default  = null
+          val expected = "/tmp/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+        "badly formed chdir and default"-{
+          val chdir = null
+          val out   = "/tmp/unified.scala"
+          val default  = null
+          val expected = "/tmp/unified.scala"
+          val actual   = util.resolve(chdir, out, default, ".h", ".scala")
+          assert(expected == actual)
+        }
+      }
+
+    }
+  }
+}

--- a/bindgen/src/test/scala/FileUtilsSpec.scala
+++ b/bindgen/src/test/scala/FileUtilsSpec.scala
@@ -81,7 +81,7 @@ object Test extends TestSuite {
           val out   = null // assuming defaults means that this can be either null or ""
           val default  = null
           intercept[IllegalArgumentException] {
-            util.resolve(chdir, out, default, ".h", ".scala")
+            util.resolve(chdir:String, out, default, ".h", ".scala")
           }
         }
       }

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,13 @@ lazy val platform: Seq[Setting[_]] =
       )
   )
 
+lazy val testSettings: Seq[Setting[_]] =
+  Seq(
+    fork in Test := true,
+    libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8-SNAPSHOT" % "test",
+    testFrameworks += new TestFramework("utest.runner.Framework")
+  )
+
 lazy val disableDocs: Seq[Setting[_]] =
   Seq(sources in doc in Compile := List())
 
@@ -23,10 +30,8 @@ lazy val bindgen =
     .in(file("bindgen"))
     .enablePlugins(ScalaNativePlugin)
     .settings(platform)
+    .settings(testSettings)
     .settings(
-      fork in Test := true,
-      javaOptions in Test += "-Dnative.bin=" + (nativeLinkLL in Compile).value,
-      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % Test,
       nativeCompileLL in Compile += {
         val compiler = (nativeClang in Compile).value.getAbsolutePath
         val opts     = (nativeCompileOptions in Compile).value
@@ -45,18 +50,14 @@ lazy val bindgen =
         opath
       }
     )
-//    .settings(disableDocs)
-//    .settings(
-//      nativeVerbose := true,
-//      nativeClangOptions ++= Seq("-O2"))
+    .settings(
+      javaOptions in Test += "-Dnative.bin=" + (nativeLinkLL in Compile).value
+    )
 
 lazy val tests =
   project
     .in(file("tests"))
+    .settings(testSettings)
     .settings(
-      fork in Test := true,
-      javaOptions in Test += "-Dnative.bin=" + nativeLinkLL
-        .in(bindgen, Compile)
-        .value,
-      libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % Test
+      javaOptions in Test += "-Dnative.bin=" + nativeLinkLL.in(bindgen, Compile).value
     )

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ lazy val platform: Seq[Setting[_]] =
 lazy val testSettings: Seq[Setting[_]] =
   Seq(
     fork in Test := true,
-    libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8-SNAPSHOT" % "test",
+    //TODO: libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8-SNAPSHOT" % "test",
+    unmanagedJars in Test += new java.io.File("/tmp/utest_native0.3_2.11.jar"),
     testFrameworks += new TestFramework("utest.runner.Framework")
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,7 @@ lazy val platform: Seq[Setting[_]] =
 lazy val testSettings: Seq[Setting[_]] =
   Seq(
     fork in Test := true,
-    //TODO: libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8-SNAPSHOT" % "test",
-    unmanagedJars in Test += new java.io.File("/tmp/utest_native0.3_2.11.jar"),
+    libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8" % "test",
     testFrameworks += new TestFramework("utest.runner.Framework")
   )
 

--- a/tests/src/test/resources/samples/test002.h
+++ b/tests/src/test/resources/samples/test002.h
@@ -1,0 +1,3 @@
+#include "test001.h"
+
+int f(enum color c, SomeInt i);

--- a/tests/src/test/resources/samples/test002.scala
+++ b/tests/src/test/resources/samples/test002.scala
@@ -1,0 +1,4 @@
+def f(
+  c: enum color
+  i: SomeInt
+  ): int = extern

--- a/tests/src/test/scala/bindgen/BindgenSpec.scala
+++ b/tests/src/test/scala/bindgen/BindgenSpec.scala
@@ -1,42 +1,86 @@
 package bindgen
 
-import scala.io.Source
-import java.io.File
-import org.scalatest._
-import scala.sys.process._
+import utest._
 
-class BindgenSpec extends FunSpec {
 
-  describe("Bindgen.main") {
-    val inputDirectory = new File("src/test/resources/samples")
+object BindgenSpec extends TestSuite {
+  import scala.io.Source
+  import java.io.File
+  import scala.sys.process._
 
-    val outputDir = new File("target/bindgen-samples")
-    Option(outputDir.listFiles()).foreach(_.foreach(_.delete()))
-    outputDir.mkdirs()
+  def contentOf(name: String): String = contentOf(new File(name))
+  def contentOf(file: File)  : String = Source.fromFile(file).getLines.mkString("\n")
 
-    def contentOf(file: File) =
-      Source.fromFile(file).getLines.mkString("\n")
+  val inputDir  = new File("src/test/resources/samples")
 
-    for {
-      input <- inputDirectory.listFiles()
-      if input.getName.endsWith(".h")
-      expected = new File(inputDirectory,
-                          input.getName.replace(".h", ".scala"))
-      if expected.exists()
-    } {
-      it(s"should generate bindings for ${input.getName}") {
-        val output = new File(outputDir, expected.getName)
-        val bin = sys.props.get("native.bin").getOrElse {
-          sys.error("native.bin is not set")
-        }
-        val cmd =
-          Array(bin, "-o", output.getAbsolutePath, input.getAbsolutePath)
+  val outputDir = new File("target/bindgen-samples")
+  Option(outputDir.listFiles()).foreach(_.foreach(_.delete()))
+  outputDir.mkdirs()
 
+  val bin = sys.props.get("native.bin").getOrElse {
+    sys.error("native.bin is not set")
+  }
+
+  val util = new Object with FileUtils
+
+
+  val tests = this {
+    "ability to generate bindings"-{
+      for {
+        input <- inputDir.listFiles()                                        if input.getName.endsWith(".h")
+        expected = util.resolve(null, null, input.toString, ".h", ".scala")  if (new File(expected)).exists
+      } {
+        val actual = util.resolve(outputDir.toString, null, input.toString, ".h", ".scala")
+        println(s"Generating bindings file: ${actual}")
+
+        val cmd = Array(bin, "-o", actual, input.toString)
         assert(Process(cmd).! == 0)
-        assert(output.exists())
-        assert(contentOf(output) == contentOf(expected))
+
+        assert((new File(actual)).exists)
+        val expectedContents = contentOf(expected)
+        val actualContents   = contentOf(actual)
+        assert(expectedContents == actualContents)
       }
     }
   }
+}
 
+//FIXME: https://github.com/frgomes/scala-bindgen/issues/27
+trait FileUtils {
+  import java.io.File
+  import java.nio.file.Paths
+  import java.nio.file.Path
+
+  def mkdirs(name: String): File = mkdirs(Paths.get(name).toFile)
+  def mkdirs(file: java.io.File): File = {
+    val dir = file.getParentFile
+    if(!dir.isDirectory)
+      if (!dir.mkdirs)
+        throw new java.io.IOException(s"Cannot create directory ${dir.toString}")
+    file
+  }
+
+  def resolve(chdir: String, name: String): String = {
+    val dir  = if(null==chdir || ""==chdir) "." else chdir
+    val path = Paths.get(name)
+    if(path.isAbsolute) path.toString else Paths.get(dir, path.toString).toString
+  }
+
+  def resolve(chdir: String, name: String, default: String): String =
+    (if(name==null) "" else name) match {
+      case "-" => "-"
+      case ""  => resolve(chdir, default)
+      case _   => resolve(chdir, name)
+    }
+
+  def resolve(chdir: String, name: String, default: String, from: String, to: String): String =
+    (if(name==null) "" else name) match {
+      case "-" => "-"
+      case ""  =>
+        if(default==null)
+          throw new IllegalArgumentException("Cannot enforce extension on a null default name.")
+        else
+          resolve(chdir, default.replace(from, to))
+      case _   => resolve(chdir, name)
+    }
 }


### PR DESCRIPTION
Attempts to fix #13 

Mimics the behavior or other tools of the Linux ecosystem, like:
* passing -C DIR for saving all output files into DIR;
* Option ``-o`` is now a "unified" output file. This is subject to review and change in future if not convenient.
